### PR TITLE
Confusing error message if old ruff-lsp package installed

### DIFF
--- a/bundled/tool/server.py
+++ b/bundled/tool/server.py
@@ -23,5 +23,8 @@ update_sys_path(os.fspath(BUNDLE_DIR / "libs"))
 if __name__ == "__main__":
     from ruff_lsp import server
 
+    if not hasattr(server, "set_bundle"):
+        raise RuntimeError("ruff-vscode needs at least ruff-lsp v0.0.6")
+
     server.set_bundle(os.fspath(BUNDLE_DIR / "libs" / "bin" / server.TOOL_MODULE))
     server.start()


### PR DESCRIPTION
We have some colleagues using vscode and got an error message `AttributeError: module 'ruff_lsp.server' has no attribute 'set_bundle'`, this pr gives a mo clearer error message.


When you execute `❯ .venv\Scripts\python.exe bundled\tool\server.py` with ruff-lsp v0.0.5 you get

```
Traceback (most recent call last):
  File "src\ruff-vscode\bundled\tool\server.py", line 29, in <module>
    server.set_bundle(os.fspath(BUNDLE_DIR / "libs" / "bin" / server.TOOL_MODULE))
AttributeError: module 'ruff_lsp.server' has no attribute 'set_bundle'
```

Now you get
```
Traceback (most recent call last):
  File "src\ruff-vscode\bundled\tool\server.py", line 27, in <module>
    raise RuntimeError("ruff-vscode needs at least ruff-lsp v0.0.6")
RuntimeError: ruff-vscode needs at least ruff-lsp v0.0.6
```