### PR TITLE
Expose the ruff.trace.server setting for tracing ruff-lsp activity

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,16 @@
                     "description": "Whether to register Ruff as capable of handling `source.fixAll` actions.",
                     "scope": "window",
                     "type": "boolean"
+                },
+                "ruff.trace.server": {
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "default": "off",
+                    "markdownDescription": "Traces the communication between VSCode and the ruff-lsp."
                 }
             }
         },


### PR DESCRIPTION
## Description

Add the `*.trace.server` setting to the configuration option, so that configuration completion also works in `settings.json`.

**VSCode Reference**:

- <https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server>

**Examples of other extensions**:

- <https://github.com/redhat-developer/vscode-yaml/blob/main/package.json#L104-L113>
- and more...

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/213360027-b48bcb32-3b49-4f5c-8301-135b3571e23d.mp4
