### PR TITLE
Install the right version of ruff in aarch64 & armhf Linux targets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,9 +57,11 @@ jobs:
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
+            arch: aarch64
           - os: ubuntu-20.04
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
+            arch: armv7
           - os: macos-11
             target: x86_64-apple-darwin
             code-target: darwin-x64
@@ -83,6 +85,18 @@ jobs:
         with:
           python-version: '3.10'
       - run: python -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
+        if: ${{ !startsWith(matrix.os, 'ubuntu') || startsWith(matrix.target, 'x86_64') }}
+      - uses: uraimo/run-on-arch-action@v2
+        if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.target, 'x86_64') }}
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu20.04
+          install: |
+            apt-get update
+            apt-get install -y --no-install-recommends python3 python3-pip
+            pip3 install -U pip
+          run: |
+            python3 -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
 
       # Install Node.
       - name: Install Node.js


### PR DESCRIPTION
This only fixes the Linux issues, aarch64 Windows has the same kind of issue, macOS is fine thanks to universal2 binary.

Closes #58 
Closes #117